### PR TITLE
tee logging to logrus instead of discarding the logs locally

### DIFF
--- a/pkg/honeycomb/honeycomb.go
+++ b/pkg/honeycomb/honeycomb.go
@@ -5,7 +5,6 @@ package honeycomb
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 	"os"
 	"sync"
 
@@ -88,7 +87,6 @@ func Setup(logger *logrus.Logger) *logrus.Logger {
 
 	registerLogrusOnce.Do(func() {
 		logger.Hooks.Add(honeycombLoggingHook)
-		logger.Out = ioutil.Discard
 	})
 	return logger
 }


### PR DESCRIPTION
When logrus logging works, great! However, we often want to run and
debug locally. Howveer, we have nice run-scripts which divert all
logging to appropriate local files, and we don't want to discard that;
it can be faster and simpler to just grep a file than to get into
the whole Honeycomb thing.